### PR TITLE
Extend timeout to 5 min

### DIFF
--- a/src/tonic/mod.rs
+++ b/src/tonic/mod.rs
@@ -95,9 +95,9 @@ impl Health for HealthService {
 // Monitoring task for health checks
 async fn monitor_health_check(last_check: Arc<Mutex<Instant>>, shutdown_flag: Arc<AtomicBool>) {
     loop {
-        tokio::time::sleep(Duration::from_millis(500)).await;
+        tokio::time::sleep(Duration::from_secs(30)).await;
         let last_check_time = last_check.lock().unwrap();
-        if last_check_time.elapsed() > Duration::from_secs(1) {
+        if last_check_time.elapsed() > Duration::from_secs(300) {
             println!("Qdrant health check failed");
             shutdown_flag.store(true, Ordering::SeqCst);
             break;


### PR DESCRIPTION
We can now extend the timeout because the client can reconnect gracefully to a running process.